### PR TITLE
Fix bug where stats process would hang if there was a player with an

### DIFF
--- a/src/stats/stats_whore.py
+++ b/src/stats/stats_whore.py
@@ -198,7 +198,7 @@ def stats_whore(m_report_file):
             player = players_pilots[sortie.account_id]
         elif sortie.cls == 'aircraft_turret':
             player = players_gunners[sortie.account_id]
-        elif sortie.cls in ('tank_light', 'tank_heavy', 'tank_medium', 'tank_turret'):
+        elif sortie.cls in ('tank_light', 'tank_heavy', 'tank_medium', 'tank_turret', 'truck'):
             player = players_tankmans[sortie.account_id]
         else:
             continue
@@ -413,7 +413,7 @@ def create_profiles(tour, sorties):
         elif s.cls == 'aircraft_turret':
             players_gunners.setdefault(
                 s.account_id, Player.objects.get_or_create(profile_id=profile.id, tour_id=tour.id, type='gunner')[0])
-        elif s.cls in ('tank_light', 'tank_heavy', 'tank_medium', 'tank_turret'):
+        elif s.cls in ('tank_light', 'tank_heavy', 'tank_medium', 'tank_turret', 'truck'):
             players_tankmans.setdefault(
                 s.account_id, Player.objects.get_or_create(profile_id=profile.id, tour_id=tour.id, type='tankman')[0])
 


### PR DESCRIPTION
This fixes a bug where stats.cmd would hang if there was a player controlled GAZ AA in a mission. Player was not being found, so sortie could not be created and attached which caused a problem later.

Logs which show an example that causes the error on master branch:  https://www.mediafire.com/file/f1gy5vgkoibtb17/logs_advance_and_secure.zip/file

Stacktrace is:

```
Traceback (most recent call last):
  File "C:/Users/The Batman/il2_stats/src/manage.py", line 7, in <module>
    execute_from_command_line(sys.argv)
  File "C:\Users\The Batman\il2_stats\.venv\lib\site-packages\django\core\management\__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "C:\Users\The Batman\il2_stats\.venv\lib\site-packages\django\core\management\__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "C:\Users\The Batman\il2_stats\.venv\lib\site-packages\django\core\management\base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "C:\Users\The Batman\il2_stats\.venv\lib\site-packages\django\core\management\base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "C:\Users\The Batman\il2_stats\src\stats\management\commands\stats_whore.py", line 16, in handle
    stats_whore.main()
  File "C:\Users\The Batman\il2_stats\src\stats\stats_whore.py", line 73, in main
    stats_whore(m_report_file=m_report_file)
  File "C:\Program Files (x86)\Python35-32\lib\contextlib.py", line 30, in inner
    return func(*args, **kwds)
  File "C:\Users\The Batman\il2_stats\src\stats\stats_whore.py", line 305, in stats_whore
    params['act_object_id'] = event['sortie'].sortie_db.aircraft.id
AttributeError: 'Sortie' object has no attribute 'sortie_db'

Process finished with exit code 1
```