### PR TITLE
Bug/players tanks tally

### DIFF
--- a/src/stats/templates/pilot.html
+++ b/src/stats/templates/pilot.html
@@ -183,23 +183,44 @@
                     <div class="num">{{ player.gk_total }}</div>
                 </div>
 
-                {% if player.killboard_pve.tank_heavy %}
+                {% if player.killboard_pvp.tank_heavy %}
                 <div class="sub_item">
                     <div class="name">{% trans 'Heavy Tanks' context 'total' %}</div>
+                    <div class="num">{{ player.killboard_pvp.tank_heavy }}</div>
+                </div>
+                {% endif %}
+
+                {% if player.killboard_pvp.tank_medium %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Medium Tanks' context 'total' %}</div>
+                    <div class="num">{{ player.killboard_pvp.tank_medium }}</div>
+                </div>
+                {% endif %}
+
+                {% if player.killboard_pvp.tank_light %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Light Tanks' context 'total' %}</div>
+                    <div class="num">{{ player.killboard_pvp.tank_light }}</div>
+                </div>
+                {% endif %}
+
+                {% if player.killboard_pve.tank_heavy %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Heavy Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ player.killboard_pve.tank_heavy }}</div>
                 </div>
                 {% endif %}
 
                 {% if player.killboard_pve.tank_medium %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Medium Tanks' context 'total' %}</div>
+                    <div class="name">{% trans 'Medium Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ player.killboard_pve.tank_medium }}</div>
                 </div>
                 {% endif %}
 
                 {% if player.killboard_pve.tank_light %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Light Tanks' context 'total' %}</div>
+                    <div class="name">{% trans 'Light Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ player.killboard_pve.tank_light }}</div>
                 </div>
                 {% endif %}

--- a/src/stats/templates/pilot.html
+++ b/src/stats/templates/pilot.html
@@ -204,6 +204,13 @@
                 </div>
                 {% endif %}
 
+                {% if player.killboard_pvp.truck %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Trucks' context 'total' %}</div>
+                    <div class="num">{{ player.killboard_pvp.truck }}</div>
+                </div>
+                {% endif %}
+
                 {% if player.killboard_pve.tank_heavy %}
                 <div class="sub_item">
                     <div class="name">{% trans 'Heavy Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
@@ -241,7 +248,7 @@
 
                 {% if player.killboard_pve.truck %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Trucks' context 'total' %}</div>
+                    <div class="name">{% trans 'Trucks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ player.killboard_pve.truck }}</div>
                 </div>
                 {% endif %}

--- a/src/stats/templates/pilot_sortie.html
+++ b/src/stats/templates/pilot_sortie.html
@@ -279,10 +279,52 @@
                     <div class="right">&nbsp;</div>
                 </div>
 
-                {% if sortie.killboard_pve.tank_heavy %}
+                {% if sortie.killboard_pvp.tank_heavy %}
                     <div class="sub_row">
                         <div class="left">
                             {% trans 'Heavy Tanks' context 'total' %}
+                            <span>{{ sortie.killboard_pvp.tank_heavy }}</span>
+                        </div>
+                        <div class="right score">
+                            {{ sortie.killboard_pvp.tank_heavy }}
+                            &times;
+                            {{ score_dict.tank_heavy.ai }}
+                        </div>
+                    </div>
+                {% endif %}
+
+                {% if sortie.killboard_pvp.tank_medium %}
+                    <div class="sub_row">
+                        <div class="left">
+                            {% trans 'Medium Tanks' context 'total' %}
+                            <span>{{ sortie.killboard_pvp.tank_medium }}</span>
+                        </div>
+                        <div class="right score">
+                            {{ sortie.killboard_pvp.tank_medium }}
+                            &times;
+                            {{ score_dict.tank_medium.ai }}
+                        </div>
+                    </div>
+                {% endif %}
+
+                {% if sortie.killboard_pvp.tank_light %}
+                    <div class="sub_row">
+                        <div class="left">
+                            {% trans 'Light Tanks' context 'total' %}
+                            <span>{{ sortie.killboard_pvp.tank_light }}</span>
+                        </div>
+                        <div class="right score">
+                            {{ sortie.killboard_pvp.tank_light }}
+                            &times;
+                            {{ score_dict.tank_light.ai }}
+                        </div>
+                    </div>
+                {% endif %}
+
+                {% if sortie.killboard_pve.tank_heavy %}
+                    <div class="sub_row">
+                        <div class="left">
+                            {% trans 'Heavy Tanks' context 'total' %} ({% trans 'AI' context 'total' %})
                             <span>{{ sortie.killboard_pve.tank_heavy }}</span>
                         </div>
                         <div class="right score">
@@ -296,7 +338,7 @@
                 {% if sortie.killboard_pve.tank_medium %}
                     <div class="sub_row">
                         <div class="left">
-                            {% trans 'Medium Tanks' context 'total' %}
+                            {% trans 'Medium Tanks' context 'total' %} ({% trans 'AI' context 'total' %})
                             <span>{{ sortie.killboard_pve.tank_medium }}</span>
                         </div>
                         <div class="right score">
@@ -310,7 +352,7 @@
                 {% if sortie.killboard_pve.tank_light %}
                     <div class="sub_row">
                         <div class="left">
-                            {% trans 'Light Tanks' context 'total' %}
+                            {% trans 'Light Tanks' context 'total' %} ({% trans 'AI' context 'total' %})
                             <span>{{ sortie.killboard_pve.tank_light }}</span>
                         </div>
                         <div class="right score">

--- a/src/stats/templates/pilot_sortie.html
+++ b/src/stats/templates/pilot_sortie.html
@@ -321,6 +321,20 @@
                     </div>
                 {% endif %}
 
+                {% if sortie.killboard_pvp.truck %}
+                    <div class="sub_row">
+                        <div class="left">
+                            {% trans 'Trucks' context 'total' %}
+                            <span>{{ sortie.killboard_pvp.truck }}</span>
+                        </div>
+                        <div class="right score">
+                            {{ sortie.killboard_pvp.truck }}
+                            &times;
+                            {{ score_dict.truck.ai }}
+                        </div>
+                    </div>
+                {% endif %}
+
                 {% if sortie.killboard_pve.tank_heavy %}
                     <div class="sub_row">
                         <div class="left">
@@ -394,7 +408,7 @@
                 {% if sortie.killboard_pve.truck %}
                     <div class="sub_row">
                         <div class="left">
-                            {% trans 'Trucks' context 'total' %}
+                            {% trans 'Trucks' context 'total' %} ({% trans 'AI' context 'total' %})
                             <span>{{ sortie.killboard_pve.truck }}</span>
                         </div>
                         <div class="right score">

--- a/src/stats/templates/pilot_vlife.html
+++ b/src/stats/templates/pilot_vlife.html
@@ -160,23 +160,44 @@
                     <div class="num">{{ vlife.gk_total }}</div>
                 </div>
 
-                {% if vlife.killboard_pve.tank_heavy %}
+                {% if vlife.killboard_pvp.tank_heavy %}
                 <div class="sub_item">
                     <div class="name">{% trans 'Heavy Tanks' context 'total' %}</div>
+                    <div class="num">{{ vlife.killboard_pvp.tank_heavy }}</div>
+                </div>
+                {% endif %}
+
+                {% if vlife.killboard_pvp.tank_medium %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Medium Tanks' context 'total' %}</div>
+                    <div class="num">{{ vlife.killboard_pvp.tank_medium }}</div>
+                </div>
+                {% endif %}
+
+                {% if vlife.killboard_pvp.tank_light %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Light Tanks' context 'total' %}</div>
+                    <div class="num">{{ vlife.killboard_pvp.tank_light }}</div>
+                </div>
+                {% endif %}
+
+                {% if vlife.killboard_pve.tank_heavy %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Heavy Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ vlife.killboard_pve.tank_heavy }}</div>
                 </div>
                 {% endif %}
 
                 {% if vlife.killboard_pve.tank_medium %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Medium Tanks' context 'total' %}</div>
+                    <div class="name">{% trans 'Medium Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ vlife.killboard_pve.tank_medium }}</div>
                 </div>
                 {% endif %}
 
                 {% if vlife.killboard_pve.tank_light %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Light Tanks' context 'total' %}</div>
+                    <div class="name">{% trans 'Light Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ vlife.killboard_pve.tank_light }}</div>
                 </div>
                 {% endif %}

--- a/src/stats/templates/pilot_vlife.html
+++ b/src/stats/templates/pilot_vlife.html
@@ -181,6 +181,13 @@
                 </div>
                 {% endif %}
 
+                {% if vlife.killboard_pvp.truck %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Trucks' context 'total' %}</div>
+                    <div class="num">{{ vlife.killboard_pvp.truck }}</div>
+                </div>
+                {% endif %}
+
                 {% if vlife.killboard_pve.tank_heavy %}
                 <div class="sub_item">
                     <div class="name">{% trans 'Heavy Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
@@ -218,7 +225,7 @@
 
                 {% if vlife.killboard_pve.truck %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Trucks' context 'total' %}</div>
+                    <div class="name">{% trans 'Trucks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ vlife.killboard_pve.truck }}</div>
                 </div>
                 {% endif %}

--- a/src/stats/templates/squad.html
+++ b/src/stats/templates/squad.html
@@ -182,6 +182,13 @@
                 </div>
                 {% endif %}
 
+                {% if squad.killboard_pvp.truck %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Trucks' context 'total' %}</div>
+                    <div class="num">{{ squad.killboard_pvp.truck }}</div>
+                </div>
+                {% endif %}
+
                 {% if squad.killboard_pve.tank_heavy %}
                 <div class="sub_item">
                     <div class="name">{% trans 'Heavy Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
@@ -219,7 +226,7 @@
 
                 {% if squad.killboard_pve.truck %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Trucks' context 'total' %}</div>
+                    <div class="name">{% trans 'Trucks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ squad.killboard_pve.truck }}</div>
                 </div>
                 {% endif %}

--- a/src/stats/templates/squad.html
+++ b/src/stats/templates/squad.html
@@ -160,24 +160,45 @@
                     <div class="name">{% trans 'Destroyed ground targets' context 'total' %}</div>
                     <div class="num">{{ squad.gk_total }}</div>
                 </div>
+                
+                {% if squad.killboard_pvp.tank_heavy %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Heavy Tanks' context 'total' %}</div>
+                    <div class="num">{{ squad.killboard_pvp.tank_heavy }}</div>
+                </div>
+                {% endif %}
+
+                {% if squad.killboard_pvp.tank_medium %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Medium Tanks' context 'total' %}</div>
+                    <div class="num">{{ squad.killboard_pvp.tank_medium }}</div>
+                </div>
+                {% endif %}
+
+                {% if squad.killboard_pvp.tank_light %}
+                <div class="sub_item">
+                    <div class="name">{% trans 'Light Tanks' context 'total' %}</div>
+                    <div class="num">{{ squad.killboard_pvp.tank_light }}</div>
+                </div>
+                {% endif %}
 
                 {% if squad.killboard_pve.tank_heavy %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Heavy Tanks' context 'total' %}</div>
+                    <div class="name">{% trans 'Heavy Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ squad.killboard_pve.tank_heavy }}</div>
                 </div>
                 {% endif %}
 
                 {% if squad.killboard_pve.tank_medium %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Medium Tanks' context 'total' %}</div>
+                    <div class="name">{% trans 'Medium Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ squad.killboard_pve.tank_medium }}</div>
                 </div>
                 {% endif %}
 
                 {% if squad.killboard_pve.tank_light %}
                 <div class="sub_item">
-                    <div class="name">{% trans 'Light Tanks' context 'total' %}</div>
+                    <div class="name">{% trans 'Light Tanks' context 'total' %} ({% trans 'AI' context 'total' %})</div>
                     <div class="num">{{ squad.killboard_pve.tank_light }}</div>
                 </div>
                 {% endif %}


### PR DESCRIPTION
Kills on player tanks and player AAA were not showing up in the ground kill breakdown of a sortie/player/squad.

For example: https://imgur.com/VTqDOfY

Problem was, that tankmen_sorties were being saved, and so the kills on player tanks and player AAA were going to killboard_pvp and not killboard_pve. I've added additional lines in the templates which render player tank kills as well, as well as adding "(AI)" to tanks and trucks. 

(Vaal: I've sent you a dataset with a bugged sortie as a direct message on the il2 forums)